### PR TITLE
Fix version check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Check driver installation status
-  shell: modinfo ena | grep -i "^version:" | grep -Po "(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)$"
+  shell: modinfo ena | grep -i "^version:" | grep -Po "(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)"
   register: ena_driver_version
   changed_when: ena_driver_version.stdout != "{{ aws_ena_driver_version }}"
   ignore_errors: True


### PR DESCRIPTION
Versions can have a letter after them, such as `1.4.0g`.