### PR TITLE
Fix warnings for Ansible 2.4; increase minimum supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,10 +37,11 @@ Further information is available in the AWS ENA [documentation](http://docs.aws.
 ## Testing
 Tests are done using [molecule](http://molecule.readthedocs.io/). To run the test suite, install molecule and its dependencies and run ` molecule test` from the folder containing molecule.yml. To add additional tests, add a [testinfra](http://testinfra.readthedocs.org/) python script in the [tests](./tests/) directory, or add a function to [test_ena.py](./tests/test_ena.py). Information about available Testinfra modules is available [here](http://testinfra.readthedocs.io/en/latest/modules.html).
 
-### Example 
+### Example
+
 ```
-# Download molecule, dependencies
-$ pip install molecule
+# Download Molecule and its dependencies
+$ pip install -r requirements.txt
 
 # Change to the top-level project directory, which contains molecule.yml
 $ cd /path/to/ansible-aws-ena

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,13 +3,14 @@ galaxy_info:
   description: An Ansible role for installing AWS Elastic Networking Adapter drivers.
   company: Azavea, Inc.
   license: Apache
-  min_ansible_version: 2.2
+  min_ansible_version: 2.4
   platforms:
     - name: Ubuntu
       versions:
       - trusty
   galaxy_tags:
     - development
+    - system
 dependencies:
   - azavea.git
   - azavea.build-essential

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+molecule==1.25.1
+testinfra==1.7.1
+python-vagrant>=0.5,<0.6.99

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,10 +2,9 @@
 - name: Check driver installation status
   shell: modinfo ena | grep -i "^version:" | grep -Po "(?:(\d+)\.)?(?:(\d+)\.)?(\*|\d+)"
   register: ena_driver_version
-  changed_when: ena_driver_version.stdout != "{{ aws_ena_driver_version }}"
+  changed_when: ena_driver_version.stdout != aws_ena_driver_version
   ignore_errors: True
 
-- debug: msg="ena_driver_version is {{ ena_driver_version.stdout }}. Desired version is {{ aws_ena_driver_version }}"
-
-- include: install.yml
-  when: ena_driver_version.stdout != "{{ aws_ena_driver_version }}"
+- name: Install ENA driver
+  import_tasks: install.yml
+  when: ena_driver_version.stdout is defined and (ena_driver_version.stdout != aws_ena_driver_version)


### PR DESCRIPTION
Remove Jinja2 syntax from `when` statements and include a `requirements.txt` file for installing Ansible, Molecule, and Vagrant support for Molecule.

Ansible 2.4 is now the minimum version of Ansible that is supported for this role.

Resolves https://github.com/azavea/ansible-aws-ena/issues/6

---

**Testing**

- Follow the instructions in the `README` to install Molecule
- Execute `molecule test` from the root of the repository
- Confirm that there are no deprecation warnings in the Ansible/Molecule output